### PR TITLE
Fix missing “o” in xCoordinate variable name.

### DIFF
--- a/lib/gibs/gibs.js
+++ b/lib/gibs/gibs.js
@@ -91,7 +91,7 @@ gibs.GeographicTilingScheme = function(options) {
 
         var xTileCoordinate = (longitude - rectangle.west) / xTileWidth | 0;
         if ( xTileCoordinate >= xTiles ) {
-            xTileCordinate = xTiles - 1;
+            xTileCoordinate = xTiles - 1;
         }
 
         var latitude = position.latitude;


### PR DESCRIPTION
> ReferenceError: xTileCordinate is not defined