### PR TITLE
Fix OpenLayers fetching tiles outside of the extent

### DIFF
--- a/examples/openlayers/antarctic-epsg3031.js
+++ b/examples/openlayers/antarctic-epsg3031.js
@@ -41,7 +41,6 @@ window.onload = function () {
   var source = new ol.source.WMTS({
     url: 'https://gibs-{a-c}.earthdata.nasa.gov/wmts/epsg3031/best/wmts.cgi?TIME=2013-12-01',
     layer: 'MODIS_Terra_CorrectedReflectance_TrueColor',
-    extent: [-4194304, -4194304, 4194304, 4194304],
     format: 'image/jpeg',
     matrixSet: 'EPSG3031_250m',
 
@@ -60,7 +59,10 @@ window.onload = function () {
     })
   });
 
-  var layer = new ol.layer.Tile({ source: source });
+  var layer = new ol.layer.Tile({
+    source: source,
+    extent: [-4194304, -4194304, 4194304, 4194304]
+  });
 
   map.addLayer(layer);
 };

--- a/examples/openlayers/arctic-epsg3413.js
+++ b/examples/openlayers/arctic-epsg3413.js
@@ -41,7 +41,6 @@ window.onload = function () {
   var source = new ol.source.WMTS({
     url: 'https://gibs-{a-c}.earthdata.nasa.gov/wmts/epsg3413/best/wmts.cgi?TIME=2013-06-01',
     layer: 'MODIS_Terra_CorrectedReflectance_TrueColor',
-    extent: [-4194304, -4194304, 4194304, 4194304],
     format: 'image/jpeg',
     matrixSet: 'EPSG3413_250m',
 
@@ -60,7 +59,10 @@ window.onload = function () {
     })
   });
 
-  var layer = new ol.layer.Tile({ source: source });
+  var layer = new ol.layer.Tile({
+    source: source,
+    extent: [-4194304, -4194304, 4194304, 4194304]
+  });
 
   map.addLayer(layer);
 };

--- a/examples/openlayers/geographic-epsg4326.js
+++ b/examples/openlayers/geographic-epsg4326.js
@@ -56,7 +56,8 @@ window.onload = function () {
   });
 
   var layer = new ol.layer.Tile({
-    source: source
+    source: source,
+    extent: [-180, -90, 180, 90]
   });
 
   map.addLayer(layer);


### PR DESCRIPTION
The OpenLayers examples are fetching tiles outside the declared extent for every projection except Web Mercator. 

- Add extent to layer definition
- Remove extent from source definition as it appears to do nothing