### PR TITLE
WV-2668 MapLibre Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ source for
   * [Demonstration of GIBS Layers](https://nasa-gibs.github.io/gibs-web-examples/examples/cesium/gibs-layers)
 * Mapbox GL
   * [Web Mercator (EPSG:3857)](https://nasa-gibs.github.io/gibs-web-examples/examples/mapbox-gl/webmercator-epsg3857.html)
+* Maplibre GL
+  * [Web Mercator (EPSG:3857)](https://nasa-gibs.github.io/gibs-web-examples/examples/maplibre-gl/webmercator-epsg3857.html)
 * Bing
   * [Web Mercator (EPSG:3857)](https://nasa-gibs.github.io/gibs-web-examples/examples/bing/webmercator-epsg3857.html)
 * Google Maps

--- a/examples/maplibre-gl/webmercator-epsg3857.html
+++ b/examples/maplibre-gl/webmercator-epsg3857.html
@@ -33,7 +33,7 @@
 <body>
   <div id='map'></div>
   <div id='attribution'>
-    <a href='http://mapbox.com'>Mapbox</a>
+    <a href='https://maplibre.org'>MapLibre</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
     <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/mapbox-gl/webmercator-epsg3857.js'>
       View Source


### PR DESCRIPTION
### Description

In the GIBS Web Examples readme (https://github.com/nasa-gibs/gibs-web-examples) please update the following:

Add MapLibre example to the "Live Examples" section (https://nasa-gibs.github.io/gibs-web-examples/examples/maplibre-gl/webmercator-epsg3857.html)
In the MapLibre live example above, change the link for Mapbox in the lower right corner to "MapLibre" and change to this link https://maplibre.org/

### Fixes for WV-2668

### Testing
- `git fetch --all`
- `git checkout wv-2668-maplibre-links`
- `npm i`
- `npm start`
- Open the readme and view it as a MarkDown file.
- Click on link for MapLibre under live examples. This should link to the MapLibre live example.
- Go to `http://localhost:3000`
- Click on the MapLibre example
- On the bottom right, the UI box should say MapLibre
- Clicking on that link will lead to https://maplibre.org
