### PR TITLE
WV-2675 Source Code Links to Main

### DIFF
--- a/examples/bing/example.css
+++ b/examples/bing/example.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/bing/webmercator-epsg3857.html
+++ b/examples/bing/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/bing/webmercator-epsg3857.js
+++ b/examples/bing/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/cesium/example.css
+++ b/examples/cesium/example.css
@@ -1,7 +1,7 @@
 /*
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/geographic-epsg4326.html
+++ b/examples/cesium/geographic-epsg4326.html
@@ -35,7 +35,7 @@ limitations under the License.
     <div id='attribution'>
         <a href='http://cesiumjs.org'>Cesium</a>
         <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-        <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/cesium/geographic-epsg4326.js'>
+        <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/cesium/geographic-epsg4326.js'>
             View Source
         </a>
     </div>

--- a/examples/cesium/geographic-epsg4326.html
+++ b/examples/cesium/geographic-epsg4326.html
@@ -2,7 +2,7 @@
 <!--
 GIBS Web Examples
 
-Copyright 2013 - 2020 United States Government as represented by the
+Copyright 2013 - 2023 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 

--- a/examples/cesium/geographic-epsg4326.js
+++ b/examples/cesium/geographic-epsg4326.js
@@ -1,7 +1,7 @@
 /**
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/gibs-layers/demo.css
+++ b/examples/cesium/gibs-layers/demo.css
@@ -1,7 +1,7 @@
 /*
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/gibs-layers/demo.js
+++ b/examples/cesium/gibs-layers/demo.js
@@ -1,7 +1,7 @@
 /**
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/gibs-layers/index.html
+++ b/examples/cesium/gibs-layers/index.html
@@ -2,7 +2,7 @@
 <!--
 GIBS Web Examples
 
-Copyright 2013 - 2020 United States Government as represented by the
+Copyright 2013 - 2023 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 

--- a/examples/cesium/gibs-layers/viewer.js
+++ b/examples/cesium/gibs-layers/viewer.js
@@ -1,7 +1,7 @@
 /**
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/gibs.js
+++ b/examples/cesium/gibs.js
@@ -1,7 +1,7 @@
 /**
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/time.html
+++ b/examples/cesium/time.html
@@ -2,7 +2,7 @@
 <!--
 GIBS Web Examples
 
-Copyright 2013 - 2020 United States Government as represented by the
+Copyright 2013 - 2023 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 

--- a/examples/cesium/time.html
+++ b/examples/cesium/time.html
@@ -35,7 +35,7 @@ limitations under the License.
     <div id="attribution">
         <a href='http://cesiumjs.org'>Cesium</a>
         <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-        <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/cesium/time.js'>
+        <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/cesium/time.js'>
             View Source
         </a>
     </div>

--- a/examples/cesium/time.js
+++ b/examples/cesium/time.js
@@ -1,7 +1,7 @@
 /**
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/cesium/webmercator-epsg3857.html
+++ b/examples/cesium/webmercator-epsg3857.html
@@ -34,7 +34,7 @@ limitations under the License.
     <div id="attribution">
         <a href='http://cesiumjs.org'>Cesium</a>
         <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-        <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/cesium/webmercator-epsg3857.js'>
+        <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/cesium/webmercator-epsg3857.js'>
             View Source
         </a>
     </div>

--- a/examples/cesium/webmercator-epsg3857.html
+++ b/examples/cesium/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
 GIBS Web Examples
 
-Copyright 2013 - 2020 United States Government as represented by the
+Copyright 2013 - 2023 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 

--- a/examples/cesium/webmercator-epsg3857.js
+++ b/examples/cesium/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
 * GIBS Web Examples
 *
-* Copyright 2013 - 2020 United States Government as represented by the
+* Copyright 2013 - 2023 United States Government as represented by the
 * Administrator of the National Aeronautics and Space Administration.
 * All Rights Reserved.
 *

--- a/examples/google/example.css
+++ b/examples/google/example.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/google/webmercator-epsg3857.html
+++ b/examples/google/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/google/webmercator-epsg3857.js
+++ b/examples/google/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/antarctic-epsg3031.html
+++ b/examples/leaflet/antarctic-epsg3031.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/leaflet/antarctic-epsg3031.js
+++ b/examples/leaflet/antarctic-epsg3031.js
@@ -62,7 +62,7 @@ window.onload = function () {
     attribution:
       '<a href="https://wiki.earthdata.nasa.gov/display/GIBS">' +
       'NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp;' +
-      '<a href="https://github.com/nasa-gibs/web-examples/blob/master/examples/leaflet/antarctic-epsg3031.js">' +
+      '<a href="https://github.com/nasa-gibs/web-examples/blob/main/examples/leaflet/antarctic-epsg3031.js">' +
       'View Source' +
       '</a>'
   });

--- a/examples/leaflet/antarctic-epsg3031.js
+++ b/examples/leaflet/antarctic-epsg3031.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/arctic-epsg3413.html
+++ b/examples/leaflet/arctic-epsg3413.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/leaflet/arctic-epsg3413.js
+++ b/examples/leaflet/arctic-epsg3413.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/arctic-epsg3413.js
+++ b/examples/leaflet/arctic-epsg3413.js
@@ -61,7 +61,7 @@ window.onload = function () {
     attribution:
       '<a href="https://wiki.earthdata.nasa.gov/display/GIBS">' +
       'NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp;' +
-      '<a href="https://github.com/nasa-gibs/web-examples/blob/master/examples/leaflet/arctic-epsg3413.js">' +
+      '<a href="https://github.com/nasa-gibs/web-examples/blob/main/examples/leaflet/arctic-epsg3413.js">' +
       'View Source' +
       '</a>'
   });

--- a/examples/leaflet/example.css
+++ b/examples/leaflet/example.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/geographic-epsg4326.html
+++ b/examples/leaflet/geographic-epsg4326.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/leaflet/geographic-epsg4326.js
+++ b/examples/leaflet/geographic-epsg4326.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/geographic-epsg4326.js
+++ b/examples/leaflet/geographic-epsg4326.js
@@ -74,7 +74,7 @@ window.onload = function () {
     attribution:
       '<a href="https://wiki.earthdata.nasa.gov/display/GIBS">' +
       'NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp;' +
-      '<a href="https://github.com/nasa-gibs/web-examples/blob/master/examples/leaflet/geographic-epsg4326.js">' +
+      '<a href="https://github.com/nasa-gibs/web-examples/blob/main/examples/leaflet/geographic-epsg4326.js">' +
       'View Source' +
       '</a>'
   });

--- a/examples/leaflet/time.css
+++ b/examples/leaflet/time.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/time.html
+++ b/examples/leaflet/time.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/leaflet/time.js
+++ b/examples/leaflet/time.js
@@ -109,7 +109,7 @@ window.onload = function () {
       attribution:
         '<a href="https://wiki.earthdata.nasa.gov/display/GIBS">' +
         'NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp;' +
-        '<a href="https://github.com/nasa-gibs/web-examples/blob/master/examples/leaflet/time.js">' +
+        '<a href="https://github.com/nasa-gibs/web-examples/blob/main/examples/leaflet/time.js">' +
         'View Source' +
         '</a>'
     });

--- a/examples/leaflet/time.js
+++ b/examples/leaflet/time.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/webmercator-epsg3857.html
+++ b/examples/leaflet/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/leaflet/webmercator-epsg3857.js
+++ b/examples/leaflet/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/leaflet/webmercator-epsg3857.js
+++ b/examples/leaflet/webmercator-epsg3857.js
@@ -51,7 +51,7 @@ window.onload = function () {
     attribution:
       '<a href="https://wiki.earthdata.nasa.gov/display/GIBS">' +
       'NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp;' +
-      '<a href="https://github.com/nasa-gibs/web-examples/blob/master/examples/leaflet/webmercator-epsg3857.js">' +
+      '<a href="https://github.com/nasa-gibs/web-examples/blob/main/examples/leaflet/webmercator-epsg3857.js">' +
       'View Source' +
       '</a>'
   });

--- a/examples/mapbox-gl/example.css
+++ b/examples/mapbox-gl/example.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/mapbox-gl/webmercator-epsg3857.html
+++ b/examples/mapbox-gl/webmercator-epsg3857.html
@@ -35,7 +35,7 @@
   <div id='attribution'>
     <a href='http://mapbox.com'>Mapbox</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-    <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/mapbox-gl/webmercator-epsg3857.js'>
+    <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/mapbox-gl/webmercator-epsg3857.js'>
       View Source
     </a>
   </div>

--- a/examples/mapbox-gl/webmercator-epsg3857.html
+++ b/examples/mapbox-gl/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/mapbox-gl/webmercator-epsg3857.js
+++ b/examples/mapbox-gl/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/maplibre-gl/example.css
+++ b/examples/maplibre-gl/example.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/maplibre-gl/webmercator-epsg3857.html
+++ b/examples/maplibre-gl/webmercator-epsg3857.html
@@ -35,7 +35,7 @@
   <div id='attribution'>
     <a href='https://maplibre.org'>MapLibre</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-    <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/mapbox-gl/webmercator-epsg3857.js'>
+    <a href='https://github.com/nasa-gibs/gibs-web-examples/blob/main/examples/maplibre-gl/webmercator-epsg3857.js'>
       View Source
     </a>
   </div>

--- a/examples/maplibre-gl/webmercator-epsg3857.html
+++ b/examples/maplibre-gl/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/maplibre-gl/webmercator-epsg3857.js
+++ b/examples/maplibre-gl/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/antarctic-epsg3031.html
+++ b/examples/openlayers/antarctic-epsg3031.html
@@ -35,7 +35,7 @@
   <div id='attribution'>
     <a href='http://openlayers.org'>OpenLayers</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-    <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/openlayers/antarctic-epsg3031.js'>
+    <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/openlayers/antarctic-epsg3031.js'>
       View Source
     </a>
   </div>

--- a/examples/openlayers/antarctic-epsg3031.html
+++ b/examples/openlayers/antarctic-epsg3031.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/antarctic-epsg3031.js
+++ b/examples/openlayers/antarctic-epsg3031.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/arctic-epsg3413.html
+++ b/examples/openlayers/arctic-epsg3413.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/arctic-epsg3413.html
+++ b/examples/openlayers/arctic-epsg3413.html
@@ -36,7 +36,7 @@
   <div id="attribution">
     <a href='http://openlayers.org'>OpenLayers</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-    <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/openlayers/arctic-epsg3413.js'>
+    <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/openlayers/arctic-epsg3413.js'>
       View Source
     </a>
   </div>

--- a/examples/openlayers/arctic-epsg3413.js
+++ b/examples/openlayers/arctic-epsg3413.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/example.css
+++ b/examples/openlayers/example.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/geographic-epsg4326.html
+++ b/examples/openlayers/geographic-epsg4326.html
@@ -36,7 +36,7 @@
   <div id='attribution'>
     <a href='http://openlayers.org'>OpenLayers</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-    <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/openlayers/geographic-epsg4326.js'>
+    <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/openlayers/geographic-epsg4326.js'>
       View Source
     </a>
   </div>

--- a/examples/openlayers/geographic-epsg4326.html
+++ b/examples/openlayers/geographic-epsg4326.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/geographic-epsg4326.js
+++ b/examples/openlayers/geographic-epsg4326.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/time.css
+++ b/examples/openlayers/time.css
@@ -1,7 +1,7 @@
 /*
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/time.html
+++ b/examples/openlayers/time.html
@@ -40,7 +40,7 @@
     <div id='attribution'>
         <a href='http://openlayers.org'>OpenLayers</a>
         <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-        <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/openlayers/time.js'>
+        <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/openlayers/time.js'>
             View Source
         </a>
     </div>

--- a/examples/openlayers/time.html
+++ b/examples/openlayers/time.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/time.js
+++ b/examples/openlayers/time.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/examples/openlayers/vectors/geographic-epsg4326-vector-basic.html
+++ b/examples/openlayers/vectors/geographic-epsg4326-vector-basic.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/vectors/geographic-epsg4326-vector-hover.html
+++ b/examples/openlayers/vectors/geographic-epsg4326-vector-hover.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/vectors/geographic-epsg4326-vector-mapbox-styles.html
+++ b/examples/openlayers/vectors/geographic-epsg4326-vector-mapbox-styles.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/webmercator-epsg3857.html
+++ b/examples/openlayers/webmercator-epsg3857.html
@@ -36,7 +36,7 @@
   <div id='attribution'>
     <a href='http://openlayers.org'>OpenLayers</a>
     <a href='https://wiki.earthdata.nasa.gov/display/GIBS'>NASA EOSDIS GIBS</a>
-    <a href='https://github.com/nasa-gibs/web-examples/blob/master/examples/openlayers/webmercator-epsg3857.js'>
+    <a href='https://github.com/nasa-gibs/web-examples/blob/main/examples/openlayers/webmercator-epsg3857.js'>
       View Source
     </a>
   </div>

--- a/examples/openlayers/webmercator-epsg3857.html
+++ b/examples/openlayers/webmercator-epsg3857.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 

--- a/examples/openlayers/webmercator-epsg3857.js
+++ b/examples/openlayers/webmercator-epsg3857.js
@@ -1,7 +1,7 @@
 /**
  * GIBS Web Examples
  *
- * Copyright 2013 - 2020 United States Government as represented by the
+ * Copyright 2013 - 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <!--
    GIBS Web Examples
 
-   Copyright 2013 - 2020 United States Government as represented by the
+   Copyright 2013 - 2023 United States Government as represented by the
    Administrator of the National Aeronautics and Space Administration.
    All Rights Reserved.
 


### PR DESCRIPTION
### Description

It appears the "View Source" links in the Live Examples are pointing to `master`. These should be updated to point to `main`.
For example: [https://nasa-gibs.github.io/gibs-web-examples/examples/mapbox-gl/webmercator-epsg3857.html ](https://nasa-gibs.github.io/gibs-web-examples/examples/mapbox-gl/webmercator-epsg3857.html)The "View Source" link points to https://github.com/nasa-gibs/web-examples/blob/master/examples/mapbox-gl/webmercator-epsg3857.js  but should point to `main`.
The MapLibre example (https://nasa-gibs.github.io/gibs-web-examples/examples/maplibre-gl/webmercator-epsg3857.html) is also not pointing to the correct URL. It should point to https://github.com/nasa-gibs/gibs-web-examples/blob/main/examples/maplibre-gl/webmercator-epsg3857.js 
Also update the copyrights to 2023.

### Test

- `git fetch --all`
- `git checkout wv-2675-links-main`
- `npm i`
- `npm start`
- go to `http://localhost:3000`
- Select each example. Check that the UI overlay link on the bottom right for source code, links to main instead of master.