### PR TITLE
Upgrade MapLibre GL to 5.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This example uses [Mapbox GL](https://www.mapbox.com/help/define-mapbox-gl/) ver
 
 ## MapLibre GL
 
-This example uses [MapLibre GL](https://maplibre.org/maplibre-gl-js-docs/api/) version 2.4.0.
+This example uses [MapLibre GL](https://maplibre.org/maplibre-gl-js-docs/api/) version 5.14.0.
 
 ## Bing
 

--- a/examples/maplibre-gl/webmercator-epsg3857.html
+++ b/examples/maplibre-gl/webmercator-epsg3857.html
@@ -23,10 +23,10 @@
 <head>
   <title>GIBS MapLibre GL Example - Web Mercator (EPSG:3857)</title>
 
-  <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
+  <link href='https://unpkg.com/maplibre-gl@5.14.0/dist/maplibre-gl.css' rel='stylesheet' />
   <link rel='stylesheet' href='example.css' />
 
-  <script type='text/javascript' src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+  <script type='text/javascript' src='https://unpkg.com/maplibre-gl@5.14.0/dist/maplibre-gl.js'></script>
   <script src='webmercator-epsg3857.js'></script>
 </head>
 


### PR DESCRIPTION
## Summary

Upgrades MapLibre GL from version 2.4.0 to 5.14.0